### PR TITLE
Teh/checkindex

### DIFF
--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -5,7 +5,7 @@ using Base.Broadcast: bitcache_chunks, bitcache_size, dumpbitcache,
 if isdefined(Base, :OneTo)
     broadcastshape(x...) = Base.to_shape(broadcast_shape(x...))
 else
-    broadcastshape = broadcast_shape
+    const broadcastshape = broadcast_shape
 end
 
 # Check that all arguments are broadcast compatible with shape

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -79,7 +79,7 @@ end
 
 
 if isdefined(Base, :checkindex)
-    Base.checkindex(::Type{Bool}, ::UnitRange, ::NAtype) =
+    Base.checkindex(::Type{Bool}, ::AbstractUnitRange, ::NAtype) =
         throw(NAException("cannot index an array with a DataArray containing NA values"))
 else
     Base.checkbounds(::Type{Bool}, sz::Int, I::AbstractDataVector{Bool}) = length(I) == sz


### PR DESCRIPTION
Fixes tests on both Julia 0.4 and Julia 0.5. Note this is a PR against @tkelman's PR #205.

Do you know you folks have some ambiguities?

``` jl
julia> using DataArrays
INFO: Recompiling stale cache file /home/tim/.julia/lib/v0.5/DataArrays.ji for module DataArrays.

julia> using Base.Test

julia> detect_ambiguities(DataArrays, Base)
WARNING: both ArrayViews and Base export "view"; uses of it in module StatsBase must be qualified
Skipping DataArrays.wmean!
Skipping Base.<|
Skipping Base.>:
Skipping Base.@MIME
Skipping Base.cluster_manager
2-element Array{Tuple{Method,Method},1}:
 (promote_rule{T}(::Type{T}, ::Type{DataArrays.NAtype}) at /home/tim/.julia/v0.5/DataArrays/src/natype.jl:37,promote_rule{S,T}(::Type{Nullable{S}}, ::Type{T}) at nullable.jl:26)                  
 (sum(A::DataArrays.DataArray, region) at /home/tim/.julia/v0.5/DataArrays/src/reducedim.jl:312,sum(v::AbstractArray, w::StatsBase.WeightVec) at /home/tim/.julia/v0.5/StatsBase/src/weights.jl:34)
```

Not that you have to resolve these if they don't cause a problem, but I thought you'd want to know.
